### PR TITLE
Update doc to use `max-duration-ms`

### DIFF
--- a/docs/diehard.core.html
+++ b/docs/diehard.core.html
@@ -61,7 +61,7 @@
   <li><code>:abort-if</code> specify a function <code>(fn [return-value
   exception-thrown])</code>, abort retry if the function returns true</li>
   <li><code>:max-retries</code> abort retry when max attempts reached</li>
-  <li><code>:max-duration</code> abort retry when duration reached</li>
+  <li><code>:max-duration-ms</code> abort retry when duration reached</li>
 </ul>
 <h5><a href="#delay" name="delay"></a>Delay</h5>
 <ul>
@@ -148,7 +148,7 @@
   <li><code>:abort-if</code> specify a function <code>(fn [return-value
   exception-thrown])</code>, abort retry if the function returns true</li>
   <li><code>:max-retries</code> abort retry when max attempts reached</li>
-  <li><code>:max-duration</code> abort retry when duration reached</li>
+  <li><code>:max-duration-ms</code> abort retry when duration reached</li>
 </ul>
 <h5><a href="#delay" name="delay"></a>Delay</h5>
 <ul>

--- a/src/diehard/core.clj
+++ b/src/diehard/core.clj
@@ -139,7 +139,7 @@
 * `:abort-if` specify a function `(fn [return-value
   exception-thrown])`, abort retry if the function returns true
 * `:max-retries` abort retry when max attempts reached
-* `:max-duration` abort retry when duration reached
+* `:max-duration-ms` abort retry when duration reached
 
 ##### Delay
 
@@ -230,7 +230,7 @@ the last execution. If `:circuit-breaker` is set, it will throw
 * `:abort-if` specify a function `(fn [return-value
   exception-thrown])`, abort retry if the function returns true
 * `:max-retries` abort retry when max attempts reached
-* `:max-duration` abort retry when duration reached
+* `:max-duration-ms` abort retry when duration reached
 
 ##### Delay
 


### PR DESCRIPTION
The implementation  `:max-duration-ms` key for maximum duration, so
reconciling documentation to match that.