### PR TITLE
A couple of documentation tweaks

### DIFF
--- a/src/diehard/core.clj
+++ b/src/diehard/core.clj
@@ -188,6 +188,9 @@ And use `:policy` option in option map.
   criteria)
 * `:on-retry` accepts a function which takes `result`, `exception` as
   arguments, called when a retry attempted.
+* `:on-retries-exceeded` accepts a function which takes `result`,
+  `exception` as arguments, called when max retries or max duration have
+  been exceeded.
 
 ##### Use predefined listeners
 

--- a/src/diehard/core.clj
+++ b/src/diehard/core.clj
@@ -186,8 +186,8 @@ And use `:policy` option in option map.
 * `:on-success` accepts a function which takes `result` as arguments,
   called when existing `retry` block with success (mismatches retry
   criteria)
-* `:on-retry` accepts a function which takes `result` as arguments,
-  called when a retry attempted.
+* `:on-retry` accepts a function which takes `result`, `exception` as
+  arguments, called when a retry attempted.
 
 ##### Use predefined listeners
 


### PR DESCRIPTION
I noticed one missing retry handler (`:on-retries-exceeded`) in the documentation and the `:on-retry` documentation didn't mention two arguments.