### PR TITLE
Fix failing circuit breaker deifinition when timeout given

### DIFF
--- a/src/diehard/circuit_breaker.clj
+++ b/src/diehard/circuit_breaker.clj
@@ -1,7 +1,6 @@
 (ns diehard.circuit-breaker
   (:require [diehard.util :as u])
   (:import [java.time Duration]
-           [java.time.temporal ChronoUnit]
            [net.jodah.failsafe CircuitBreaker]))
 
 (def ^{:const true :no-doc true}
@@ -24,7 +23,7 @@
     (when (contains? opts :fail-when)
       (.handleResult cb (:fail-when opts)))
     (when-let [timeout (:timeout-ms opts)]
-      (.withTimeout cb timeout ChronoUnit/MILLIS))
+      (.withTimeout cb (Duration/ofMillis timeout)))
 
     (when-let [delay (:delay-ms opts)]
       (.withDelay cb (Duration/ofMillis delay)))

--- a/test/diehard/core_test.clj
+++ b/test/diehard/core_test.clj
@@ -190,7 +190,10 @@
     (is (= (Ratio. 10 10) (.getSuccessThreshold test-cb-p3))))
   (testing "success threshold"
     (defcircuitbreaker test-cb-p4 {:success-threshold 10})
-    (is (= 10 (.getNumerator (.getSuccessThreshold test-cb-p4))))))
+    (is (= 10 (.getNumerator (.getSuccessThreshold test-cb-p4)))))
+  (testing "timeout"
+    (defcircuitbreaker test-cb-p5 {:timeout-ms 1})
+    (is (= 1000000 (.getNano (.getTimeout test-cb-p5))))))
 
 (deftest test-retry-policy-params
   (testing "retry policy param"


### PR DESCRIPTION
The `defcircuitbreaker` macro fails when given the `:timeout-ms` option. This is due to incorrect `withTimeout` call.