### PR TITLE
Interruptable timeout policy

### DIFF
--- a/src/diehard/spec.clj
+++ b/src/diehard/spec.clj
@@ -124,7 +124,8 @@
 (s/def :timeout/async? boolean?)
 (s/def :timeout/timeout-new
   (only-keys :req-un [:timeout/timeout-ms]
-             :opt-un [:timeout/on-success
+             :opt-un [:timeout/interrupt?
+                      :timeout/on-success
                       :timeout/on-failure]))
 
 ;; rate limiter

--- a/src/diehard/timeout.clj
+++ b/src/diehard/timeout.clj
@@ -7,6 +7,8 @@
   (util/verify-opt-map-keys-with-spec :timeout/timeout-new opts)
   (let [duration (Duration/ofMillis (:timeout-ms opts))
         timeout-policy (Timeout/of duration)]
+    (when (contains? opts :interrupt?)
+      (.withCancel timeout-policy true))
     (when (contains? opts :on-success)
       (.onSuccess timeout-policy (util/fn-as-consumer (:on-success opts))))
     (when (contains? opts :on-failure)

--- a/test/diehard/timeout_test.clj
+++ b/test/diehard/timeout_test.clj
@@ -14,11 +14,21 @@
                       (Thread/sleep 25)
                       "result"))))
 
-  (testing "get with timeout exception"
+  (testing "get exceeds timeout and throws timeout exception"
     (is (thrown? TimeoutExceededException
                  (with-timeout {:timeout-ms timeout-duration}
                    (Thread/sleep 60)
                    "result"))))
+  (testing "get given interrupt flag set exceeds timeout and throws"
+    (let [start (System/currentTimeMillis)
+          timeout-ms 500]
+      (is (thrown? TimeoutExceededException
+                   (with-timeout {:timeout-ms timeout-ms
+                                  :interrupt? true}
+                                 (Thread/sleep 5000)
+                                 "result")))
+      (let [end (System/currentTimeMillis)]
+        (is (< (- end start) (* 1.5 timeout-ms))))))
 
   (testing "get on success callback"
     (let [call-count (atom 0)]


### PR DESCRIPTION
Exposing failsafe interrupt flag on the timeout policy.

Wrapped execution context not stopping after specified time and being at the mercy of it ending quickly is not the expected behaviour when you use timeouts .