### PR TITLE
Add support for rate-based circuit-breaker

### DIFF
--- a/src/diehard/circuit_breaker.clj
+++ b/src/diehard/circuit_breaker.clj
@@ -8,6 +8,7 @@
 (def ^{:const true :no-doc true}
   allowed-circuit-breaker-option-keys
   #{:failure-threshold :failure-threshold-ratio :failure-threshold-ratio-in-period
+    :failure-rate-threshold-in-period
     :success-threshold :success-threshold-ratio
     :delay-ms :timeout-ms
 
@@ -37,6 +38,10 @@
     (when-let [[failures executions period-ms]
                (:failure-threshold-ratio-in-period opts)]
       (.withFailureThreshold cb failures executions (Duration/ofMillis period-ms)))
+
+    (when-let [[failure-rate executions period-ms]
+               (:failure-rate-threshold-in-period opts)]
+      (.withFailureRateThreshold cb failure-rate executions (Duration/ofMillis period-ms)))
 
     (when-let [success-threshold (:success-threshold opts)]
       (.withSuccessThreshold cb success-threshold))

--- a/src/diehard/spec.clj
+++ b/src/diehard/spec.clj
@@ -91,6 +91,7 @@
 (s/def :circuit-breaker/failure-threshold int?)
 (s/def :circuit-breaker/failure-threshold-ratio (s/tuple int? int?))
 (s/def :circuit-breaker/failure-threshold-ratio-in-period (s/tuple int? int? int?))
+(s/def :circuit-breaker/failure-rate-threshold-in-period (s/tuple int? int? int?))
 (s/def :circuit-breaker/success-threshold int?)
 (s/def :circuit-breaker/success-threshold-ratio (s/tuple int? int?))
 
@@ -112,6 +113,7 @@
                       :circuit-breaker/failure-threshold
                       :circuit-breaker/failure-threshold-ratio
                       :circuit-breaker/failure-threshold-ratio-in-period
+                      :circuit-breaker/failure-rate-threshold-in-period
                       :circuit-breaker/success-threshold
                       :circuit-breaker/success-threshold-ratio
 

--- a/test/diehard/core_test.clj
+++ b/test/diehard/core_test.clj
@@ -236,7 +236,12 @@
     (is (= 10 (.getSuccessThreshold test-cb-p3))))
   (testing "success threshold"
     (defcircuitbreaker test-cb-p4 {:success-threshold 10})
-    (is (= 10 (.getSuccessThreshold test-cb-p4)))))
+    (is (= 10 (.getSuccessThreshold test-cb-p4))))
+  (testing "failure rate threshold"
+    (defcircuitbreaker test-cb-p5 {:failure-rate-threshold-in-period [5 30 1000]})
+    (is (= 5 (.getFailureRateThreshold test-cb-p5)))
+    (is (= 30 (.getFailureExecutionThreshold test-cb-p5)))
+    (is (= 1000 (.toMillis (.getFailureThresholdingPeriod test-cb-p5))))))
 
 (deftest test-retry-policy-params
   (testing "retry policy param"


### PR DESCRIPTION
Adds support for Failsafe's rate-based CircuitBreaker using [withFailureRateThreshold](https://jodah.net/failsafe/javadoc/net/jodah/failsafe/CircuitBreaker.html#withFailureRateThreshold-int-int-java.time.Duration-).

Naming is a compromise between Failsafe ("rate") and existing names ("in-period"), but I realize "rate" vs "ratio" may end up being a source of confusion. I had assumed that the `:failure-threshold-ratio...` options used rate thresholding, but was surprised to see that they are actually count-based.

Based on my reading of the Failsafe docs and some testing, `(.withFailureThreshold cb 50 500)` (aka `:failure-threshold-ratio [50 500]`) would actually trip after 50 total failures as long as 500 executions have happened _ever_, not 50 out of the last 500 executions. That is, repeating 1000 successes and 10 failures 5 times (for a total of 50 failures and 5000 successes) would end up tripping the circuit, even though the failure ratio in this case is < 1% in total (50 out of 5050), and only 2% in the last 500 (10 out of 500).