### PR TITLE
Circuit breaker thresholds part 2

### DIFF
--- a/src/diehard/circuit_breaker.clj
+++ b/src/diehard/circuit_breaker.clj
@@ -32,8 +32,8 @@
     (when-let [failure-threshold (:failure-threshold opts)]
       (.withFailureThreshold cb failure-threshold))
 
-    (when-let [[failures executions] (:failure-threshold-ratio opts)]
-      (.withFailureThreshold cb failures))
+    (when-let [[^int failures ^int executions] (:failure-threshold-ratio opts)]
+      (.withFailureThreshold cb failures executions))
 
     (when-let [[failures executions period-ms]
                (:failure-threshold-ratio-in-period opts)]

--- a/src/diehard/core.clj
+++ b/src/diehard/core.clj
@@ -382,6 +382,7 @@ retry block.
 * `:failure-threshold`
 * `:failure-threshold-ratio`
 * `:failure-threshold-ratio-in-period`
+* `:failure-rate-threshold-in-period`
 * `:success-threshold`
 * `:success-threshold-ratio` All these options are to determine at
   what condition the circuit breaker is open.

--- a/src/diehard/core.clj
+++ b/src/diehard/core.clj
@@ -379,13 +379,24 @@ retry block.
 
 * `:delay-ms` required. the delay for `:open` circuit breaker to turn
   into `:half-open`.
-* `:failure-threshold`
-* `:failure-threshold-ratio`
-* `:failure-threshold-ratio-in-period`
-* `:failure-rate-threshold-in-period`
-* `:success-threshold`
-* `:success-threshold-ratio` All these options are to determine at
-  what condition the circuit breaker is open.
+* `:failure-threshold failures` sets the number of failures that must occur
+  before the circuit opens (count-based).
+* `:failure-threshold-ratio [failures executions]` sets the failure ratio that
+  must occur before the circuit opens (count-based). e.g. [4 10] means 4 out of
+  the last 10 executions must fail to open the circuit.
+* `:failure-threshold-ratio-in-period [failures min-executions period-ms]` sets
+  the number of failures that must occur within a time period to open the
+  circuit (time-based). Must also exceed `min-executions` within the time
+  period to open the circuit.
+* `:failure-rate-threshold-in-period [failure-pct min-executions period-ms]`
+  sets the percent of executions that must fail (1-100) within the time period
+  to open the circuit (time-based). Must also exceed `min-executions` within
+  the time period to open the circuit.
+* `:success-threshold successes` sets the number of successful executions that
+  must occur when in `:half-open` to return to a `:closed` state.
+* `:success-threshold-ratio [successes executions]` sets the success ratio that
+  must occur when in `:half-open` to return to a `:closed` state. e.g. [6 10]
+  means 6 out of the last 10 executions must succeed to close the circuit.
 
 ##### Listeners
 


### PR DESCRIPTION
Sorry this took a while! Following up on #44 with more docs and a test case.

I also discovered while I was at it that the `:failure-threshold-ratio` option was ignoring the `executions` arg, so it was behaving exactly like `:failure-threshold`. I went ahead and updated that and added a test, but I'm happy to leave that part out or move it to a different PR if you're concerned about introducing a breaking change.