### PR TITLE
Failsafe 3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [net.jodah/failsafe "2.4.4"]
+                 [dev.failsafe/failsafe "3.0.0"]
                  [org.clojure/spec.alpha "0.2.194"]]
   :plugins [[lein-codox "0.10.7"]
             [lein-eftest "0.5.9"]]

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [dev.failsafe/failsafe "3.0.0"]
+                 [dev.failsafe/failsafe "3.0.1"]
                  [org.clojure/spec.alpha "0.2.194"]]
   :plugins [[lein-codox "0.10.7"]
             [lein-eftest "0.5.9"]]

--- a/src/diehard/core.clj
+++ b/src/diehard/core.clj
@@ -50,8 +50,9 @@
      ~@body))
 
 (defn ^:no-doc retry-policy-from-config [policy-map]
-  ;; TODO: ":policy support"
-  (let [policy (RetryPolicy/builder)]
+  (let [policy (if-let [policy (:policy policy-map)]
+                 (RetryPolicy/builder (.getConfig policy))
+                 (RetryPolicy/builder))]
 
     (when (contains? policy-map :abort-if)
       (.abortIf policy ^BiPredicate (u/bipredicate (:abort-if policy-map))))

--- a/src/diehard/core.clj
+++ b/src/diehard/core.clj
@@ -10,12 +10,12 @@
            [java.time.temporal ChronoUnit]
            [java.util List]
            [java.util.function BiPredicate Predicate]
-           [net.jodah.failsafe Failsafe Fallback RetryPolicy FailsafeExecutor
+           [dev.failsafe Failsafe Fallback RetryPolicy FailsafeExecutor
             ExecutionContext FailsafeException
             CircuitBreakerOpenException]
-           [net.jodah.failsafe.event ExecutionAttemptedEvent
+           [dev.failsafe.event ExecutionAttemptedEvent
             ExecutionCompletedEvent]
-           [net.jodah.failsafe.function CheckedSupplier ContextualSupplier
+           [dev.failsafe.function CheckedSupplier ContextualSupplier
             CheckedFunction]))
 
 (def ^:const ^:no-doc
@@ -50,9 +50,8 @@
      ~@body))
 
 (defn ^:no-doc retry-policy-from-config [policy-map]
-  (let [policy (if-let [policy (:policy policy-map)]
-                 (.copy ^RetryPolicy policy)
-                 (RetryPolicy.))]
+  ;; TODO: ":policy support"
+  (let [policy (RetryPolicy/builder)]
 
     (when (contains? policy-map :abort-if)
       (.abortIf policy ^BiPredicate (u/bipredicate (:abort-if policy-map))))
@@ -93,27 +92,27 @@
     ;; events
     (when-let [on-abort (:on-abort policy-map)]
       (.onAbort policy
-                (u/fn-as-consumer
+                (u/wrap-event-listener
                  (fn [^ExecutionCompletedEvent event]
                    (with-context event
                      (on-abort (.getResult event) (.getFailure event)))))))
     (when-let [on-failed-attempt (:on-failed-attempt policy-map)]
       (.onFailedAttempt policy
-                        (u/fn-as-consumer
+                        (u/wrap-event-listener
                          (fn [^ExecutionAttemptedEvent event]
                            (with-context event
                              (on-failed-attempt (.getLastResult event)
                                                 (.getLastFailure event)))))))
     (when-let [on-failure (:on-failure policy-map)]
       (.onFailure policy
-                  (u/fn-as-consumer
+                  (u/wrap-event-listener
                    (fn [^ExecutionCompletedEvent event]
                      (with-context event
                        (on-failure (.getResult event) (.getFailure event)))))))
 
     (when-let [on-retry (:on-retry policy-map)]
       (.onRetry policy
-                (u/fn-as-consumer
+                (u/wrap-event-listener
                  (fn [^ExecutionAttemptedEvent event]
                    (with-context event
                      (on-retry (.getLastResult event)
@@ -121,28 +120,28 @@
 
     (when-let [on-retries-exceeded (:on-retries-exceeded policy-map)]
       (.onRetriesExceeded policy
-                          (u/fn-as-consumer
+                          (u/wrap-event-listener
                            (fn [^ExecutionCompletedEvent event]
                              (with-context event
                                (on-retries-exceeded (.getResult event) (.getFailure event)))))))
 
     (when-let [on-success (:on-success policy-map)]
       (.onSuccess policy
-                  (u/fn-as-consumer
+                  (u/wrap-event-listener
                    (fn [^ExecutionCompletedEvent event]
                      (with-context event
                        (on-success (.getResult event)))))))
 
-    policy))
+    (.build policy)))
 
 (defn ^:no-doc fallback [opts]
   (when-some [fb (:fallback opts)]
-    (Fallback/of ^CheckedFunction
-     (u/fn-as-checked-function
-      (fn [^ExecutionAttemptedEvent exec-event]
-        (let [fb (if-not (fn? fb) (constantly fb) fb)]
-          (with-context exec-event
-            (fb (.getLastResult exec-event) (.getLastFailure exec-event)))))))))
+    (.build (Fallback/builder ^CheckedFunction
+                              (u/fn-as-checked-function
+                               (fn [^ExecutionAttemptedEvent exec-event]
+                                 (let [fb (if-not (fn? fb) (constantly fb) fb)]
+                                   (with-context exec-event
+                                     (fb (.getLastResult exec-event) (.getLastFailure exec-event))))))))))
 
 (defmacro ^{:doc "Predefined retry policy.
 #### Available options
@@ -339,7 +338,7 @@ It will work together with retry policy as quit criteria.
            failsafe# (Failsafe/with ^List policies#)
            failsafe# (if-let [on-complete# (:on-complete the-opt#)]
                        (.onComplete failsafe#
-                                    (u/fn-as-consumer
+                                    (u/wrap-event-listener
                                      (fn [^ExecutionCompletedEvent event#]
                                        (with-context event#
                                          (on-complete# (.getResult event#)

--- a/src/diehard/spec.clj
+++ b/src/diehard/spec.clj
@@ -2,7 +2,7 @@
   (:require [clojure.spec.alpha :as s]
             [diehard.rate-limiter :as dr]
             [diehard.bulkhead :as db])
-  (:import [net.jodah.failsafe RetryPolicy CircuitBreaker]))
+  (:import [dev.failsafe RetryPolicy CircuitBreaker]))
 
 ;; copied from https://groups.google.com/forum/#!topic/clojure/fti0eJdPQJ8
 (defmacro only-keys

--- a/src/diehard/timeout.clj
+++ b/src/diehard/timeout.clj
@@ -1,16 +1,16 @@
 (ns diehard.timeout
   (:require [diehard.util :as util])
   (:import [java.time Duration]
-           [net.jodah.failsafe Timeout]))
+           [dev.failsafe Timeout]))
 
 (defn timeout-policy-from-config-map [opts]
   (util/verify-opt-map-keys-with-spec :timeout/timeout-new opts)
   (let [duration (Duration/ofMillis (:timeout-ms opts))
-        timeout-policy (Timeout/of duration)]
+        timeout-policy (Timeout/builder duration)]
     (when (contains? opts :interrupt?)
-      (.withCancel timeout-policy true))
+      (.withInterrupt timeout-policy))
     (when (contains? opts :on-success)
-      (.onSuccess timeout-policy (util/fn-as-consumer (:on-success opts))))
+      (.onSuccess timeout-policy (util/wrap-event-listener (:on-success opts))))
     (when (contains? opts :on-failure)
-      (.onFailure timeout-policy (util/fn-as-consumer (:on-failure opts))))
-    timeout-policy))
+      (.onFailure timeout-policy (util/wrap-event-listener (:on-failure opts))))
+    (.build timeout-policy)))

--- a/src/diehard/util.clj
+++ b/src/diehard/util.clj
@@ -1,7 +1,8 @@
 (ns ^:no-doc diehard.util
   (:require [clojure.spec.alpha :as s])
-  (:import [net.jodah.failsafe.function CheckedRunnable CheckedConsumer
+  (:import [dev.failsafe.function CheckedRunnable CheckedConsumer
             CheckedFunction CheckedSupplier]
+           [dev.failsafe.event EventListener]
            [java.util.function Predicate BiPredicate]))
 
 (defn verify-opt-map-keys [opt-map allowed-keys]
@@ -49,3 +50,8 @@
 
 (defn as-vector [v]
   (if (vector? v) v [v]))
+
+(defn wrap-event-listener [f]
+  (reify EventListener
+    (accept [_ e]
+      (f e))))

--- a/test/diehard/core_test.clj
+++ b/test/diehard/core_test.clj
@@ -195,27 +195,24 @@
       (is (= execution-count @execution-counter))
       (is (= execution-count @fallback-counter))))
 
-  (comment "disable for now"
-    (testing "predefined policy"
-     (defretrypolicy the-test-policy
-       {:retry-if (fn [v e] (< v 10))})
+  (testing "predefined policy"
+    (defretrypolicy the-test-policy
+      {:retry-if (fn [v e] (< v 10))})
 
-     (is (= 10 (with-retry {:policy the-test-policy} *executions*)))))
+    (is (= 10 (with-retry {:policy the-test-policy} *executions*))))
 
-  (comment "disabled for now"
-           (testing "predefined policy with customization"
-     (defretrypolicy the-test-policy
-       {:retry-if (fn [v e] (< v 10))})
+  (testing "predefined policy with customization"
+    (defretrypolicy the-test-policy
+      {:retry-if (fn [v e] (< v 10))})
 
-     (is (= 4 (with-retry {:policy the-test-policy
-                           :max-retries 4}
-                *executions*)))))
+    (is (= 4 (with-retry {:policy the-test-policy
+                          :max-retries 4}
+               *executions*))))
 
-  (comment "disabled for now"
-           (testing "issue #43"
-     (defretrypolicy policy-43 {:max-retries 2
-                                :retry-if (fn [v _] (< v 10))})
-     (is (= 2 (with-retry {:policy policy-43} *executions*)))))
+  (testing "issue #43"
+    (defretrypolicy policy-43 {:max-retries 2
+                               :retry-if (fn [v _] (< v 10))})
+    (is (= 2 (with-retry {:policy policy-43} *executions*))))
 
   (testing "RuntimeException"
     (let [retries (atom 0)]

--- a/test/diehard/core_test.clj
+++ b/test/diehard/core_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [diehard.circuit-breaker :as cb]
             [diehard.core :refer :all])
-  (:import [net.jodah.failsafe CircuitBreakerOpenException]
+  (:import [dev.failsafe CircuitBreakerOpenException]
            [java.util.concurrent CountDownLatch]))
 
 (deftest test-retry
@@ -195,24 +195,27 @@
       (is (= execution-count @execution-counter))
       (is (= execution-count @fallback-counter))))
 
-  (testing "predefined policy"
-    (defretrypolicy the-test-policy
-      {:retry-if (fn [v e] (< v 10))})
+  (comment "disable for now"
+    (testing "predefined policy"
+     (defretrypolicy the-test-policy
+       {:retry-if (fn [v e] (< v 10))})
 
-    (is (= 10 (with-retry {:policy the-test-policy} *executions*))))
+     (is (= 10 (with-retry {:policy the-test-policy} *executions*)))))
 
-  (testing "predefined policy with customization"
-    (defretrypolicy the-test-policy
-      {:retry-if (fn [v e] (< v 10))})
+  (comment "disabled for now"
+           (testing "predefined policy with customization"
+     (defretrypolicy the-test-policy
+       {:retry-if (fn [v e] (< v 10))})
 
-    (is (= 4 (with-retry {:policy the-test-policy
-                          :max-retries 4}
-               *executions*))))
+     (is (= 4 (with-retry {:policy the-test-policy
+                           :max-retries 4}
+                *executions*)))))
 
-  (testing "issue #43"
-    (defretrypolicy policy-43 {:max-retries 2
-                               :retry-if (fn [v _] (< v 10))})
-    (is (= 2 (with-retry {:policy policy-43} *executions*))))
+  (comment "disabled for now"
+           (testing "issue #43"
+     (defretrypolicy policy-43 {:max-retries 2
+                                :retry-if (fn [v _] (< v 10))})
+     (is (= 2 (with-retry {:policy policy-43} *executions*)))))
 
   (testing "RuntimeException"
     (let [retries (atom 0)]
@@ -227,21 +230,21 @@
 (deftest test-circuit-breaker-params
   (testing "failure threshold ratio"
     (defcircuitbreaker test-cb-p1 {:failure-threshold-ratio [7 10]})
-    (is (= 7 (.getFailureThreshold test-cb-p1))))
+    (is (= 7 (.. test-cb-p1 (getConfig) (getFailureThreshold)))))
   (testing "failure threshold"
     (defcircuitbreaker test-cb-p2 {:failure-threshold 7})
-    (is (= 7 (.getFailureThreshold test-cb-p2))))
+    (is (= 7 (.. test-cb-p2 (getConfig) (getFailureThreshold)))))
   (testing "success threshold ratio"
     (defcircuitbreaker test-cb-p3 {:success-threshold-ratio [10 10]})
-    (is (= 10 (.getSuccessThreshold test-cb-p3))))
+    (is (= 10 (.. test-cb-p3 (getConfig) (getSuccessThreshold)))))
   (testing "success threshold"
     (defcircuitbreaker test-cb-p4 {:success-threshold 10})
-    (is (= 10 (.getSuccessThreshold test-cb-p4))))
+    (is (= 10 (.. test-cb-p4 (getConfig) (getSuccessThreshold)))))
   (testing "failure rate threshold"
     (defcircuitbreaker test-cb-p5 {:failure-rate-threshold-in-period [5 30 1000]})
-    (is (= 5 (.getFailureRateThreshold test-cb-p5)))
-    (is (= 30 (.getFailureExecutionThreshold test-cb-p5)))
-    (is (= 1000 (.toMillis (.getFailureThresholdingPeriod test-cb-p5))))))
+    (is (= 5 (.. test-cb-p5 (getConfig) (getFailureRateThreshold))))
+    (is (= 30 (.. test-cb-p5 (getConfig) (getFailureExecutionThreshold))))
+    (is (= 1000 (.. test-cb-p5 (getConfig) (getFailureThresholdingPeriod) (toMillis))))))
 
 (deftest test-retry-policy-params
   (testing "retry policy param"
@@ -249,10 +252,10 @@
                         :max-duration-ms 2000
                         :jitter-factor 0.5
                         :max-retries 10})
-    (is (= 1000 (.. rp (getDelay) (toMillis))))
-    (is (= 2000 (.. rp (getMaxDuration) (toMillis))))
-    (is (= 0.5 (.. rp (getJitterFactor))))
-    (is (= 10 (.. rp (getMaxRetries))))))
+    (is (= 1000 (.. rp (getConfig) (getDelay) (toMillis))))
+    (is (= 2000 (.. rp (getConfig) (getMaxDuration) (toMillis))))
+    (is (= 0.5 (.. rp (getConfig) (getJitterFactor))))
+    (is (= 10 (.. rp (getConfig) (getMaxRetries))))))
 
 (deftest test-circuit-breaker
   (testing "circuit open"

--- a/test/diehard/timeout_test.clj
+++ b/test/diehard/timeout_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [diehard.core :refer :all])
   (:import [java.time Duration]
-           [net.jodah.failsafe TimeoutExceededException]
+           [dev.failsafe TimeoutExceededException]
            [java.util.concurrent ExecutionException]
            [clojure.lang ExceptionInfo]))
 


### PR DESCRIPTION
This changeset adopt API changes in Failsafe 3. 

At the moment pre-defined policy is not working because of the removal of `.copy` methods from policy API: https://github.com/failsafe-lib/failsafe/issues/310

It's still possible to copy them within diehard library, but we can wait to see if this can be implemented from upstream.