### PR TITLE
Use interrupt? as a boolean

### DIFF
--- a/src/diehard/timeout.clj
+++ b/src/diehard/timeout.clj
@@ -7,7 +7,7 @@
   (util/verify-opt-map-keys-with-spec :timeout/timeout-new opts)
   (let [duration (Duration/ofMillis (:timeout-ms opts))
         timeout-policy (Timeout/builder duration)]
-    (when (contains? opts :interrupt?)
+    (when (:interrupt? opts)
       (.withInterrupt timeout-policy))
     (when (contains? opts :on-success)
       (.onSuccess timeout-policy (util/wrap-event-listener (:on-success opts))))


### PR DESCRIPTION
By using the value at the `:interrupt?` key, we make so that `{:interrupt? false}` doesn't cause .withInterrupt to be called.