### PR TITLE
Allow circuit breaker :on-complete listener

### DIFF
--- a/src/diehard/circuit_breaker.clj
+++ b/src/diehard/circuit_breaker.clj
@@ -14,7 +14,7 @@
 
     :fail-if :fail-on :fail-when
 
-    :on-open :on-close :on-half-open})
+    :on-open :on-close :on-half-open :on-complete})
 
 (defn circuit-breaker [opts]
   (u/verify-opt-map-keys-with-spec :circuit-breaker/circuit-breaker opts)

--- a/src/diehard/spec.clj
+++ b/src/diehard/spec.clj
@@ -101,6 +101,7 @@
 (s/def :circuit-breaker/on-open fn?)
 (s/def :circuit-breaker/on-close fn?)
 (s/def :circuit-breaker/on-half-open fn?)
+(s/def :circuit-breaker/on-complete fn?)
 
 (s/def :circuit-breaker/circuit-breaker
   (only-keys :opt-un [:circuit-breaker/fail-if
@@ -117,6 +118,7 @@
                       :circuit-breaker/on-open
                       :circuit-breaker/on-half-open
                       :circuit-breaker/on-close
+                      :circuit-breaker/on-complete
 
                       :circuit-breaker/delay-ms
                       :circuit-breaker/timeout-ms]))


### PR DESCRIPTION
This patch makes sure that we don't fail (spec and allowed keys) when the circuit breaker configuration contains `:on-complete`.