### PR TITLE
allow :rate-limiter/rate to be floats, to have floating points rates (0.5 => 1 req every 2 seconds)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ execution if the open condition triggered.
 
 A rate limiter protects your code block to run limited times per
 second. It will block or throw exception depends on your
-configuration.
+configuration. (:rate is a floating point number, and can be less than 1.0. 
+Example: 0.5 is once every two seconds.)
 
 ```clojure
 (require '[diehard.core :as dh])

--- a/src/diehard/spec.clj
+++ b/src/diehard/spec.clj
@@ -135,7 +135,9 @@
                       :timeout/on-failure]))
 
 ;; rate limiter
-(s/def :rate-limiter/rate int?)
+; allow floating point numbers, so that we can pass numbers such as 0.5, to signify 1 req / 2 seconds
+;(s/def :rate-limiter/rate int?)
+(s/def :rate-limiter/rate number?)
 (s/def :rate-limiter/max-cached-tokens int?)
 
 (s/def :rate-limiter/rate-limiter-new

--- a/test/diehard/rate_limiter_test.clj
+++ b/test/diehard/rate_limiter_test.clj
@@ -20,4 +20,23 @@
       (.shutdown pool)
       (t/is (< (Math/abs (- @counter (* rate time-secs)))
                ;; error tolerance 3%
-               (* 0.03 (* rate time-secs)))))))
+               (* 0.03 (* rate time-secs))))))
+
+  (t/testing "rate limits less than 1.0"
+    (let [rate 0.5
+          threads 1
+          pool (Executors/newFixedThreadPool threads)
+          rl (r/rate-limiter {:rate rate})
+          counter (atom 0)
+          time-secs 5]
+      (doseq [_ (range threads)]
+        (.submit pool (cast Runnable (fn []
+                                       (while true
+                                         (r/acquire! rl)
+                                         (swap! counter inc))))))
+      (Thread/sleep (* time-secs 1000))
+      (.shutdown pool)
+      (let [variance (Math/abs (- @counter (* rate time-secs)))]
+        (t/is (<= variance
+                ;; error tolerance: 0.5  -- larger, because we are dealing with slower ticks
+                0.5))))))


### PR DESCRIPTION
Thank you for such a wonderful library — I am using this library so often when I hit external API endpoints.  

Recently, I started using it to query the OpenAI API, which has token limits that often push the rate limit below one request per second.  (I use thread pools via claypoole library to fire off parallel requests)

I found that it was super-easy to specify rate limits of less then 1 req/sec, merely by specifying floats less then 1.0.  All I had to do was relax the spec to take `number?` instead of `int?`.

PS: I haven't done any formalized or methodical testing, beyond just observation, but it works well enough for my purposes.  (Before opening up this PR, I did some more measurements.  A rate limit of 0.5 will fire 10 calls in 25 seconds.  0.33 will take 36 seconds.   Good enough for me!)