### PR TITLE
fix: check if cause is null for FailsafeException in circuit breaker

### DIFF
--- a/src/diehard/core.clj
+++ b/src/diehard/core.clj
@@ -473,7 +473,9 @@ You can always check circuit breaker state with
        (catch CircuitBreakerOpenException e#
          (throw e#))
        (catch FailsafeException e#
-         (throw (.getCause e#))))))
+         (if-let [cause# (.getCause e#)]
+             (throw cause#)
+             (throw e#))))))
 
 (defmacro
   ^{:doc "Create a rate limiter with options.

--- a/test/diehard/core_test.clj
+++ b/test/diehard/core_test.clj
@@ -333,7 +333,15 @@
                  :skipped)
                (catch IllegalStateException _
                  :failure)))))
-    (is (= :open (cb/state test-cb-4)))))
+    (is (= :open (cb/state test-cb-4)))
+    
+  (testing "inner block exception has no cause"
+    (defcircuitbreaker test-cb {:failure-threshold 2
+                                    :delay-ms 100000})
+    (is (thrown? TimeoutExceededException
+                 (with-circuit-breaker test-cb
+                   (with-timeout {:timeout-ms 100}
+                     (Thread/sleep 200))))))))
 
 (deftest opt-eval-count
   (let [eval-counter (atom 0)]


### PR DESCRIPTION
This replicates the fix from #57 in the `with-circuit-breaker` code which fixes circuit-breaker equivalent of #56.