### PR TITLE
fix: resolves reflection warnings

### DIFF
--- a/src/diehard/circuit_breaker.clj
+++ b/src/diehard/circuit_breaker.clj
@@ -75,4 +75,4 @@ on current state:
   * `:close` allows all executions
   * `:half-open` only allows some of execution requests"
   [^CircuitBreaker cb]
-  (.allowsExecution cb))
+  (.tryAcquirePermit cb))

--- a/src/diehard/core.clj
+++ b/src/diehard/core.clj
@@ -9,7 +9,7 @@
   (:import [java.time Duration Instant]
            [java.time.temporal ChronoUnit]
            [java.util List Optional]
-           [dev.failsafe Failsafe Fallback RetryPolicy RetryPolicyConfig FailsafeExecutor
+           [dev.failsafe Failsafe Fallback RetryPolicy FailsafeExecutor
             ExecutionContext FailsafeException
             CircuitBreakerOpenException]
            [dev.failsafe.event ExecutionAttemptedEvent

--- a/src/diehard/core.clj
+++ b/src/diehard/core.clj
@@ -9,7 +9,7 @@
   (:import [java.time Duration Instant]
            [java.time.temporal ChronoUnit]
            [java.util List Optional]
-           [dev.failsafe Failsafe Fallback RetryPolicy FailsafeExecutor
+           [dev.failsafe Failsafe Fallback RetryPolicy RetryPolicyConfig FailsafeExecutor
             ExecutionContext FailsafeException
             CircuitBreakerOpenException]
            [dev.failsafe.event ExecutionAttemptedEvent
@@ -59,7 +59,7 @@
 
 (defn ^:no-doc retry-policy-from-config [policy-map]
   (let [policy (if-let [policy (:policy policy-map)]
-                 (RetryPolicy/builder (.getConfig policy))
+                 (RetryPolicy/builder (.getConfig ^RetryPolicy policy))
                  (RetryPolicy/builder))]
 
     (when (contains? policy-map :abort-if)
@@ -80,8 +80,8 @@
       (let [backoff-config (:backoff-ms policy-map)
             [delay max-delay multiplier] backoff-config]
         (if (nil? multiplier)
-          (.withBackoff policy delay max-delay ChronoUnit/MILLIS)
-          (.withBackoff policy delay max-delay ChronoUnit/MILLIS multiplier))))
+          (.withBackoff policy ^long delay ^long max-delay ChronoUnit/MILLIS)
+          (.withBackoff policy ^long delay ^long max-delay ChronoUnit/MILLIS ^double multiplier))))
     (when-let [delay (:delay-ms policy-map)]
       (.withDelay policy (Duration/ofMillis delay)))
     (when-let [duration (:max-duration-ms policy-map)]

--- a/src/diehard/rate_limiter.clj
+++ b/src/diehard/rate_limiter.clj
@@ -31,7 +31,7 @@
   (acquire! [this permits]
     (let [sleep (do-acquire this permits)]
       (when (> sleep 0)
-        (Thread/sleep sleep))))
+        (Thread/sleep ^long sleep))))
   (try-acquire [this]
     (try-acquire this 1))
   (try-acquire [this permits]
@@ -42,7 +42,7 @@
         false
         (do
           (when (> sleep 0)
-            (Thread/sleep sleep))
+            (Thread/sleep ^long sleep))
           true)))))
 
 (defn- refill [^TokenBucketRateLimiter rate-limiter]


### PR DESCRIPTION
Fixes #67 

Also we found a bug while upgrading to failsafe 3.3 that `allowsExecution` method has been removed.

