### PR TITLE
Fix a typing issue with a default `max-cached-tokens` value

### DIFF
--- a/src/diehard/rate_limiter.clj
+++ b/src/diehard/rate_limiter.clj
@@ -92,12 +92,13 @@
 
 (defn rate-limiter
   "Create a default rate limiter with:
-  * `rate`: permits per second
+  * `rate`: permits per second (may be a floating point, e.g. 0.5 <=> 1 req every 2 sec)
   * `max-cached-tokens`: the max size of tokens that the bucket can cache when it's idle"
-  [opts]
-  (if-let [rate (:rate opts)]
-    (let [max-cached-tokens (:max-cached-tokens opts rate)]
-      (TokenBucketRateLimiter. (/ (double rate) 1000) max-cached-tokens
+  [{:keys [rate max-cached-tokens] :as _opts}]
+  (if (some? rate)
+    (let [max-cached-tokens (or max-cached-tokens (int rate))]
+      (TokenBucketRateLimiter. (/ (double rate) 1000)
+                               max-cached-tokens
                                (atom {:reserved-tokens (double 0)
-                                      :last-refill-ts (long -1)})))
+                                      :last-refill-ts  (long -1)})))
     (throw (IllegalArgumentException. ":rate is required for rate-limiter"))))


### PR DESCRIPTION
Hi @sunng87!

There is a typing issue introduced by #61. If `:max-cached-tokens` was not provided when constructing `rate-limiter` with `:rate` < 1, the types of the two values ​​would begin to diverge (float vs. int). The fix is straightforward, yet it required me to also switch to fn params destructuring in order to avoid an unnecessary type coercion.

Cheers,
Mark