### PR TITLE
Parametrize the rate limiter with `sleep-fn`

### DIFF
--- a/src/diehard/core.clj
+++ b/src/diehard/core.clj
@@ -462,8 +462,8 @@ You can always check circuit breaker state with
 (defmacro
   ^{:doc "Create a rate limiter with options.
 
-* `:rate` execution permits per second.
-* `:max-cached-tokens` the max size of permits we can cache when idle"}
+* `:rate` execution permits per second (may be a floating point, e.g. 0.5 <=> 1 req every 2 sec)
+* `:max-cached-tokens` the max size of permit tokens that the bucket can cache when it's idle"}
   defratelimiter [name opts]
   `(def ~name (rl/rate-limiter (u/verify-opt-map-keys-with-spec :rate-limiter/rate-limiter-new ~opts))))
 
@@ -482,10 +482,9 @@ to given rate. Use `defratelimiter` to define a ratelimiter and use it as option
 
 By default it will wait forever until there is permits available. You can also specify a
 `max-wait-ms` to wait for a given time. If there's no permits in this period, this block
-will throw a Clojure `ex-info`, with `ex-data` as
+will throw a Clojure exception with a `:throttled true` entry in `ex-data`, as follows:
 
 ```clojure
-
 (try
   (with-rate-limiter {:ratelimiter myfl
                       :max-wait-ms 1000}

--- a/src/diehard/core.clj
+++ b/src/diehard/core.clj
@@ -462,8 +462,12 @@ You can always check circuit breaker state with
 (defmacro
   ^{:doc "Create a rate limiter with options.
 
-* `:rate` execution permits per second (may be a floating point, e.g. 0.5 <=> 1 req every 2 sec)
-* `:max-cached-tokens` the max size of permit tokens that the bucket can cache when it's idle"}
+* `:rate` execution permits per second (may be a floating point number, e.g.
+  0.5 <=> 1 req every 2 sec)
+* `:max-cached-tokens` the max size of permit tokens that the bucket can cache
+  when it's idle
+* `:sleep-fn` a fn of the current state, given permits and millis to sleep for
+  allowing for custom 'sleep' semantics; by default, calls `Thread/sleep`"}
   defratelimiter [name opts]
   `(def ~name (rl/rate-limiter (u/verify-opt-map-keys-with-spec :rate-limiter/rate-limiter-new ~opts))))
 

--- a/src/diehard/core.clj
+++ b/src/diehard/core.clj
@@ -466,8 +466,9 @@ You can always check circuit breaker state with
   0.5 <=> 1 req every 2 sec)
 * `:max-cached-tokens` the max size of permit tokens that the bucket can cache
   when it's idle
-* `:sleep-fn` a fn of the current state, given permits and millis to sleep for
-  allowing for custom 'sleep' semantics; by default, calls `Thread/sleep`"}
+* `:sleep-fn` a unary fn of millis to sleep for, allowing for custom sleep
+  semantics; by default, sleeps interruptedly; pass `uninterruptible-sleep`
+  to sleep uninterruptedly"}
   defratelimiter [name opts]
   `(def ~name (rl/rate-limiter (u/verify-opt-map-keys-with-spec :rate-limiter/rate-limiter-new ~opts))))
 

--- a/src/diehard/rate_limiter.clj
+++ b/src/diehard/rate_limiter.clj
@@ -73,10 +73,6 @@
       (->sleep-ms (:reserved-tokens state) (.-rate rate-limiter)))
     (catch ExceptionInfo _)))
 
-(def ^{:const true :no-doc true}
-  allowed-rate-limiter-option-keys
-  #{:rate :max-cached-tokens})
-
 (defn rate-limiter
   "Create a default rate limiter with:
   * `rate`: permits per second (may be a floating point, e.g. 0.5 <=> 1 req every 2 sec)

--- a/src/diehard/rate_limiter.clj
+++ b/src/diehard/rate_limiter.clj
@@ -98,7 +98,8 @@
                    ;; can only recur from tail position
                    (when @interrupted? (recur)))))
              (finally
-               (when @interrupted? (.interrupt (Thread/currentThread)))))))))
+               (when @interrupted?
+                 (Thread/.interrupt (Thread/currentThread)))))))))
 
 (defn rate-limiter
   "Create a default rate limiter with:

--- a/src/diehard/spec.clj
+++ b/src/diehard/spec.clj
@@ -135,14 +135,15 @@
                       :timeout/on-failure]))
 
 ;; rate limiter
-; allow floating point numbers, so that we can pass numbers such as 0.5, to signify 1 req / 2 seconds
-;(s/def :rate-limiter/rate int?)
+
 (s/def :rate-limiter/rate number?)
 (s/def :rate-limiter/max-cached-tokens int?)
+(s/def :rate-limiter/sleep-fn fn?)
 
 (s/def :rate-limiter/rate-limiter-new
   (only-keys :req-un [:rate-limiter/rate]
-             :opt-un [:rate-limiter/max-cached-tokens]))
+             :opt-un [:rate-limiter/max-cached-tokens
+                      :rate-limiter/sleep-fn]))
 
 (s/def :rate-limiter/ratelimiter #(satisfies? dr/IRateLimiter %))
 (s/def :rate-limiter/max-wait-ms int?)

--- a/src/diehard/util.clj
+++ b/src/diehard/util.clj
@@ -54,7 +54,3 @@
   (reify EventListener
     (accept [_ e]
       (f e))))
-
-(defn sleep [^long ms]
-  (when (pos? ms)
-    (Thread/sleep ms)))

--- a/src/diehard/util.clj
+++ b/src/diehard/util.clj
@@ -54,3 +54,7 @@
   (reify EventListener
     (accept [_ e]
       (f e))))
+
+(defn sleep [^long ms]
+  (when (pos? ms)
+    (Thread/sleep ms)))

--- a/test/diehard/core_test.clj
+++ b/test/diehard/core_test.clj
@@ -390,7 +390,7 @@
       (let [counter0 (atom 0)]
         (try
           (while (< @counter0 200)
-            (with-rate-limiter {:ratelimiter my-rl
+            (with-rate-limiter {:ratelimiter my-rl3
                                 :max-wait-ms 1}
               (my-fn counter0)))
           (is false)

--- a/test/diehard/core_test.clj
+++ b/test/diehard/core_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :refer :all]
             [diehard.circuit-breaker :as cb]
             [diehard.core :refer :all])
-  (:import [dev.failsafe CircuitBreakerOpenException TimeoutExceededException]
+  (:import [clojure.lang IExceptionInfo]
+           [dev.failsafe CircuitBreakerOpenException TimeoutExceededException]
            [java.util.concurrent CountDownLatch]))
 
 (deftest test-retry
@@ -395,6 +396,7 @@
               (my-fn counter0)))
           (is false)
           (catch Exception e
+            (is (instance? IExceptionInfo e))
             (is (:throttled (ex-data e))))))))
 
   (testing "permits"

--- a/test/diehard/rate_limiter_test.clj
+++ b/test/diehard/rate_limiter_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer [deftest testing is]]
             [diehard.rate-limiter :as rl])
   (:import [java.time Duration]
-           [java.util.concurrent ExecutorService Executors Future]))
+           [java.util.concurrent ExecutorService Executors Future TimeUnit]))
 
 (def default-error
   "Relative error in percent. 3% by default."
@@ -31,7 +31,9 @@
                        (swap! counter inc)))))
     (Thread/sleep (Duration/ofSeconds run-time-sec))
     (ExecutorService/.shutdown pool)
-    @counter))
+    (let [terminated? (ExecutorService/.awaitTermination pool 1 TimeUnit/SECONDS)]
+      {:terminated? terminated?
+       :count       @counter})))
 
 (deftest rate-limiter-test
   (testing "high rates"
@@ -39,31 +41,47 @@
       (let [rate 1000
             rate-limiter (rl/rate-limiter {:rate rate})
             time-sec 2
-            count (run-rate-limited-counting rate-limiter time-sec)]
-        (is (approx== (* rate time-sec) count))))
+            {:keys [terminated? count]} (run-rate-limited-counting rate-limiter
+                                                                   time-sec)]
+        (is terminated?
+            "Terminates successfully, without timeout")
+        (is (approx== (* rate time-sec) count)
+            "Count must be close to an expected value")))
 
     (testing "uninterruptible sleep"
       (let [rate 1000
             rate-limiter (rl/rate-limiter {:rate     rate
                                            :sleep-fn rl/uninterruptible-sleep})
             time-sec 2
-            count (run-rate-limited-counting rate-limiter time-sec)]
-        (is (approx== (* rate time-sec) count)))))
+            {:keys [terminated? count]} (run-rate-limited-counting rate-limiter
+                                                                   time-sec)]
+        (is terminated?
+            "Terminates successfully, without timeout")
+        (is (approx== (* rate time-sec) count)
+            "Count must be close to an expected value"))))
 
   (testing "low rates (less than 1.0)"
     (testing "interruptible sleep"
       (let [rate 0.5
             rate-limiter (rl/rate-limiter {:rate rate})
             time-sec 5
-            count (run-rate-limited-counting rate-limiter time-sec)]
+            {:keys [terminated? count]} (run-rate-limited-counting rate-limiter
+                                                                   time-sec)]
+        (is terminated?
+            "Terminates successfully, without timeout")
         ;; exact error tolerance, since we are dealing with much slower ticks
-        (is (approx== (* rate time-sec) count 1))))
+        (is (approx== (* rate time-sec) count 1)
+            "Count must be close to an expected value")))
 
     (testing "uninterruptible sleep"
       (let [rate 0.5
             rate-limiter (rl/rate-limiter {:rate     rate
                                            :sleep-fn rl/uninterruptible-sleep})
             time-sec 5
-            count (run-rate-limited-counting rate-limiter time-sec)]
+            {:keys [terminated? count]} (run-rate-limited-counting rate-limiter
+                                                                   time-sec)]
+        (is terminated?
+            "Terminates successfully, without timeout")
         ;; exact error tolerance, since we are dealing with much slower ticks
-        (is (approx== (* rate time-sec) count 1))))))
+        (is (approx== (* rate time-sec) count 1)
+            "Count must be close to an expected value")))))

--- a/test/diehard/rate_limiter_test.clj
+++ b/test/diehard/rate_limiter_test.clj
@@ -1,8 +1,7 @@
 (ns diehard.rate-limiter-test
   (:require [clojure.test :refer [deftest testing is]]
             [diehard.rate-limiter :as rl])
-  (:import [java.time Duration]
-           [java.util.concurrent ExecutorService Executors Future TimeUnit]
+  (:import [java.util.concurrent ExecutorService Executors Future TimeUnit]
            [java.util.concurrent.atomic AtomicBoolean]))
 
 (def default-error
@@ -43,7 +42,7 @@
                          (catch Exception ex
                            (when-not (= ::stop (:type (ex-data ex)))
                              (throw ex)))))))
-      (Thread/sleep (Duration/ofSeconds run-time-sec))
+      (Thread/sleep ^long (* 1000 run-time-sec))
       (do-shutdown! pool)
       {:await-fn (fn [timeout-ms]
                    (ExecutorService/.awaitTermination

--- a/test/diehard/rate_limiter_test.clj
+++ b/test/diehard/rate_limiter_test.clj
@@ -47,32 +47,32 @@
       (do-shutdown! pool)
       {:await-fn (fn [timeout-ms]
                    (ExecutorService/.awaitTermination
-                     pool timeout-ms TimeUnit/MILLISECONDS))
+                    pool timeout-ms TimeUnit/MILLISECONDS))
        :stop-fn  #(AtomicBoolean/.set stop? true)
        :counter  counter})))
 
 (defn- run-rate-limited-counting:interruption []
   (run-rate-limited-counting
-    :proceed-run? (constantly true)
-    :do-shutdown! ExecutorService/.shutdownNow))
+   :proceed-run? (constantly true)
+   :do-shutdown! ExecutorService/.shutdownNow))
 
 (defn- run-rate-limited-counting:custom-flag []
   (let [running? (AtomicBoolean. true)]
     (run-rate-limited-counting
-      :proceed-run? #(AtomicBoolean/.get running?)
-      :do-shutdown! (fn [pool]
-                      (AtomicBoolean/.set running? false)
-                      (ExecutorService/.shutdown pool)))))
+     :proceed-run? #(AtomicBoolean/.get running?)
+     :do-shutdown! (fn [pool]
+                     (AtomicBoolean/.set running? false)
+                     (ExecutorService/.shutdown pool)))))
 
 (defn- run-rate-limited-counting:exception []
   (let [throw? (AtomicBoolean. false)]
     (run-rate-limited-counting
-      :proceed-run? #(if (AtomicBoolean/.get throw?)
-                       (throw (Exception. "Task failed!"))
-                       true)
-      :do-shutdown! (fn [pool]
-                      (AtomicBoolean/.set throw? true)
-                      (ExecutorService/.shutdown pool)))))
+     :proceed-run? #(if (AtomicBoolean/.get throw?)
+                      (throw (Exception. "Task failed!"))
+                      true)
+     :do-shutdown! (fn [pool]
+                     (AtomicBoolean/.set throw? true)
+                     (ExecutorService/.shutdown pool)))))
 
 (deftest rate-limiter-at-high-rates-test
   (testing "high rates"

--- a/test/diehard/rate_limiter_test.clj
+++ b/test/diehard/rate_limiter_test.clj
@@ -1,42 +1,98 @@
 (ns diehard.rate-limiter-test
-  (:require  [clojure.test :as t]
-             [diehard.rate-limiter :as r])
-  (:import [java.util.concurrent Executors]))
+  (:require [clojure.test :refer [deftest testing is]]
+            [diehard.rate-limiter :as rl])
+  (:import [java.time Duration]
+           [java.util.concurrent ExecutorService Executors Future]))
 
-(t/deftest rate-limiter-test
-  (t/testing "base case"
-    (let [rate 1000
-          threads 32
-          pool (Executors/newFixedThreadPool threads)
-          rl (r/rate-limiter {:rate rate})
-          counter (atom 0)
-          time-secs 2]
-      (doseq [_ (range threads)]
-        (.submit pool (cast Runnable (fn []
-                                       (while true
-                                         (r/acquire! rl)
-                                         (swap! counter inc))))))
-      (Thread/sleep (* time-secs 1000))
-      (.shutdown pool)
-      (t/is (< (Math/abs (- @counter (* rate time-secs)))
-               ;; error tolerance 3%
-               (* 0.03 (* rate time-secs))))))
+(def default-error
+  "Relative error in percent. 3% by default."
+  0.03)
 
-  (t/testing "rate limits less than 1.0"
-    (let [rate 0.5
-          threads 1
-          pool (Executors/newFixedThreadPool threads)
-          rl (r/rate-limiter {:rate rate})
-          counter (atom 0)
-          time-secs 5]
-      (doseq [_ (range threads)]
-        (.submit pool (cast Runnable (fn []
-                                       (while true
-                                         (r/acquire! rl)
-                                         (swap! counter inc))))))
-      (Thread/sleep (* time-secs 1000))
-      (.shutdown pool)
-      (let [variance (Math/abs (- @counter (* rate time-secs)))]
-        (t/is (<= variance
-                ;; error tolerance: 0.5  -- larger, because we are dealing with slower ticks
-                  0.5))))))
+(defn- approx==
+  ([expected actual]
+   (approx== expected actual (* default-error expected)))
+  ([expected actual tolerance]
+   (< (abs (- expected actual)) tolerance)))
+
+(defn- submit
+  ^Future [^ExecutorService executor ^Callable f]
+  (ExecutorService/.submit executor f))
+
+(deftest rate-limiter-test
+  (testing "base case"
+    (testing "interruptible sleep"
+      (let [rate 1000
+            rate-limiter (rl/rate-limiter {:rate rate})
+
+            threads 32
+            pool (Executors/newFixedThreadPool threads)
+
+            counter (atom 0)
+            time-secs 2]
+        (doseq [_ (range threads)]
+          (submit pool (fn []
+                         (while true
+                           (rl/acquire! rate-limiter)
+                           (swap! counter inc)))))
+        (Thread/sleep (Duration/ofSeconds time-secs))
+        (ExecutorService/.shutdown pool)
+        (is (approx== (* rate time-secs) @counter))))
+
+    (testing "uninterruptible sleep"
+      (let [rate 1000
+            rate-limiter (rl/rate-limiter {:rate     rate
+                                           :sleep-fn rl/uninterruptible-sleep})
+
+            threads 32
+            pool (Executors/newFixedThreadPool threads)
+
+            counter (atom 0)
+            time-secs 2]
+        (doseq [_ (range threads)]
+          (submit pool (fn []
+                         (while true
+                           (rl/acquire! rate-limiter)
+                           (swap! counter inc)))))
+        (Thread/sleep (Duration/ofSeconds time-secs))
+        (ExecutorService/.shutdown pool)
+        (is (approx== (* rate time-secs) @counter)))))
+
+  (testing "rate less than 1.0"
+    (testing "interruptible sleep"
+      (let [rate 0.5
+            rate-limiter (rl/rate-limiter {:rate rate})
+
+            threads 32
+            pool (Executors/newFixedThreadPool threads)
+
+            counter (atom 0)
+            time-secs 5]
+        (doseq [_ (range threads)]
+          (submit pool (fn []
+                         (while true
+                           (rl/acquire! rate-limiter)
+                           (swap! counter inc)))))
+        (Thread/sleep (Duration/ofSeconds time-secs))
+        (ExecutorService/.shutdown pool)
+        ;; exact error tolerance, since we are dealing with much slower ticks
+        (is (approx== (* rate time-secs) @counter 1))))
+
+    (testing "uninterruptible sleep"
+      (let [rate 0.5
+            rate-limiter (rl/rate-limiter {:rate     rate
+                                           :sleep-fn rl/uninterruptible-sleep})
+
+            threads 32
+            pool (Executors/newFixedThreadPool threads)
+
+            counter (atom 0)
+            time-secs 5]
+        (doseq [_ (range threads)]
+          (submit pool (fn []
+                         (while true
+                           (rl/acquire! rate-limiter)
+                           (swap! counter inc)))))
+        (Thread/sleep (Duration/ofSeconds time-secs))
+        (ExecutorService/.shutdown pool)
+        ;; exact error tolerance, since we are dealing with much slower ticks
+        (is (approx== (* rate time-secs) @counter 1))))))

--- a/test/diehard/rate_limiter_test.clj
+++ b/test/diehard/rate_limiter_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :refer [deftest testing is]]
             [diehard.rate-limiter :as rl])
   (:import [java.time Duration]
-           [java.util.concurrent ExecutorService Executors Future TimeUnit]))
+           [java.util.concurrent ExecutorService Executors Future TimeUnit]
+           [java.util.concurrent.atomic AtomicBoolean]))
 
 (def default-error
   "Relative error in percent. 3% by default."
@@ -14,74 +15,97 @@
   ([expected actual tolerance]
    (< (abs (- expected actual)) tolerance)))
 
+(defn- total-wait-time
+  [rate n-threads]
+  (long (* (/ 1.0 rate) n-threads 1000)))
+
 (defn- submit
   ^Future [^ExecutorService executor ^Callable f]
   (ExecutorService/.submit executor f))
 
 (defn- run-rate-limited-counting
-  [rate-limiter run-time-sec]
-  (let [threads 32
-        pool (Executors/newFixedThreadPool threads)
-
+  [rate-limiter n-threads run-time-sec]
+  (let [pool (Executors/newFixedThreadPool n-threads)
+        running? (AtomicBoolean. true)
         counter (atom 0)]
-    (doseq [_ (range threads)]
+    (doseq [_ (range n-threads)]
       (submit pool (fn []
-                     (while true
+                     (loop []
                        (rl/acquire! rate-limiter)
-                       (swap! counter inc)))))
+                       (when (AtomicBoolean/.get running?)
+                         (swap! counter inc)
+                         (recur))))))
     (Thread/sleep (Duration/ofSeconds run-time-sec))
+    (AtomicBoolean/.set running? false)
     (ExecutorService/.shutdown pool)
-    (let [terminated? (ExecutorService/.awaitTermination pool 1 TimeUnit/SECONDS)]
-      {:terminated? terminated?
-       :count       @counter})))
+    {:await-fn (fn [timeout-ms]
+                 (ExecutorService/.awaitTermination
+                   pool timeout-ms TimeUnit/MILLISECONDS))
+     :count    @counter}))
 
 (deftest rate-limiter-test
   (testing "high rates"
     (testing "interruptible sleep"
       (let [rate 1000
             rate-limiter (rl/rate-limiter {:rate rate})
-            time-sec 2
-            {:keys [terminated? count]} (run-rate-limited-counting rate-limiter
-                                                                   time-sec)]
-        (is terminated?
+            run-time-sec 2
+            n-threads 32
+            ;; tenfold be enough to cover up thread switching costs
+            term-timeout-ms (* 10 (total-wait-time rate n-threads))
+            {:keys [await-fn count]} (run-rate-limited-counting rate-limiter
+                                                                n-threads
+                                                                run-time-sec)]
+        (is (await-fn term-timeout-ms)
             "Terminates successfully, without timeout")
-        (is (approx== (* rate time-sec) count)
+        (is (approx== (* rate run-time-sec) count)
             "Count must be close to an expected value")))
 
     (testing "uninterruptible sleep"
       (let [rate 1000
             rate-limiter (rl/rate-limiter {:rate     rate
                                            :sleep-fn rl/uninterruptible-sleep})
-            time-sec 2
-            {:keys [terminated? count]} (run-rate-limited-counting rate-limiter
-                                                                   time-sec)]
-        (is terminated?
+            run-time-sec 2
+            n-threads 32
+            ;; tenfold be enough to cover up thread switching costs
+            term-timeout-ms (* 10 (total-wait-time rate n-threads))
+            {:keys [await-fn count]} (run-rate-limited-counting rate-limiter
+                                                                n-threads
+                                                                run-time-sec)]
+        (is (await-fn term-timeout-ms)
             "Terminates successfully, without timeout")
-        (is (approx== (* rate time-sec) count)
+        (is (approx== (* rate run-time-sec) count)
             "Count must be close to an expected value"))))
 
   (testing "low rates (less than 1.0)"
     (testing "interruptible sleep"
       (let [rate 0.5
             rate-limiter (rl/rate-limiter {:rate rate})
-            time-sec 5
-            {:keys [terminated? count]} (run-rate-limited-counting rate-limiter
-                                                                   time-sec)]
-        (is terminated?
+            run-time-sec 5
+            n-threads 2
+            ;; each thread will have to sleep for ≈2 seconds
+            term-timeout-ms (total-wait-time rate n-threads)
+            {:keys [await-fn count]} (run-rate-limited-counting rate-limiter
+                                                                n-threads
+                                                                run-time-sec)]
+        (is (await-fn term-timeout-ms)
             "Terminates successfully, without timeout")
         ;; exact error tolerance, since we are dealing with much slower ticks
-        (is (approx== (* rate time-sec) count 1)
+        (is (approx== (* rate run-time-sec) count 1)
             "Count must be close to an expected value")))
 
     (testing "uninterruptible sleep"
       (let [rate 0.5
             rate-limiter (rl/rate-limiter {:rate     rate
                                            :sleep-fn rl/uninterruptible-sleep})
-            time-sec 5
-            {:keys [terminated? count]} (run-rate-limited-counting rate-limiter
-                                                                   time-sec)]
-        (is terminated?
+            run-time-sec 5
+            n-threads 2
+            ;; each thread will have to sleep for ≈2 seconds
+            term-timeout-ms (total-wait-time rate n-threads)
+            {:keys [await-fn count]} (run-rate-limited-counting rate-limiter
+                                                                n-threads
+                                                                run-time-sec)]
+        (is (await-fn term-timeout-ms)
             "Terminates successfully, without timeout")
         ;; exact error tolerance, since we are dealing with much slower ticks
-        (is (approx== (* rate time-sec) count 1)
+        (is (approx== (* rate run-time-sec) count 1)
             "Count must be close to an expected value")))))

--- a/test/diehard/rate_limiter_test.clj
+++ b/test/diehard/rate_limiter_test.clj
@@ -15,7 +15,7 @@
   ([expected actual tolerance]
    (< (abs (- expected actual)) tolerance)))
 
-(defn- total-wait-time
+(defn- total-block-time
   [rate n-threads]
   (long (* (/ 1.0 rate) n-threads 1000)))
 
@@ -68,7 +68,7 @@
               run-time-sec 2
               n-threads 32
               ;; tenfold be enough to cover up thread switching costs
-              term-timeout-ms (* 10 (total-wait-time rate n-threads))
+              term-timeout-ms (* 10 (total-block-time rate n-threads))
               {:keys [await-fn count]} ((run-rate-limited-counting:interruption)
                                         rate-limiter n-threads run-time-sec)]
           (is (await-fn term-timeout-ms)
@@ -81,7 +81,7 @@
               run-time-sec 2
               n-threads 32
               ;; tenfold be enough to cover up thread switching costs
-              term-timeout-ms (* 10 (total-wait-time rate n-threads))
+              term-timeout-ms (* 10 (total-block-time rate n-threads))
               {:keys [await-fn count]} ((run-rate-limited-counting:custom-flag)
                                         rate-limiter n-threads run-time-sec)]
           (is (await-fn term-timeout-ms)
@@ -97,7 +97,7 @@
               run-time-sec 2
               n-threads 32
               ;; tenfold be enough to cover up thread switching costs
-              term-timeout-ms (* 10 (total-wait-time rate n-threads))
+              term-timeout-ms (* 10 (total-block-time rate n-threads))
               {:keys [await-fn throw-fn count]} ((run-rate-limited-counting:interruption)
                                                  rate-limiter n-threads run-time-sec)]
           (is (false? (await-fn term-timeout-ms))
@@ -115,7 +115,7 @@
               run-time-sec 2
               n-threads 32
               ;; tenfold be enough to cover up thread switching costs
-              term-timeout-ms (* 10 (total-wait-time rate n-threads))
+              term-timeout-ms (* 10 (total-block-time rate n-threads))
               {:keys [await-fn count]} ((run-rate-limited-counting:custom-flag)
                                         rate-limiter n-threads run-time-sec)]
           (is (await-fn term-timeout-ms)
@@ -132,7 +132,7 @@
               run-time-sec 5
               n-threads 2
               ;; each thread will have to sleep for ≈2 seconds
-              term-timeout-ms (total-wait-time rate n-threads)
+              term-timeout-ms (total-block-time rate n-threads)
               {:keys [await-fn count]} ((run-rate-limited-counting:interruption)
                                         rate-limiter n-threads run-time-sec)]
           (is (await-fn term-timeout-ms)
@@ -146,7 +146,7 @@
               run-time-sec 5
               n-threads 2
               ;; each thread will have to sleep for ≈2 seconds
-              term-timeout-ms (total-wait-time rate n-threads)
+              term-timeout-ms (total-block-time rate n-threads)
               {:keys [await-fn count]} ((run-rate-limited-counting:custom-flag)
                                         rate-limiter n-threads run-time-sec)]
           (is (await-fn term-timeout-ms)
@@ -163,7 +163,7 @@
               run-time-sec 5
               n-threads 2
               ;; each thread will have to sleep for ≈2 seconds
-              term-timeout-ms (total-wait-time rate n-threads)
+              term-timeout-ms (total-block-time rate n-threads)
               {:keys [await-fn throw-fn count]} ((run-rate-limited-counting:interruption)
                                                  rate-limiter n-threads run-time-sec)]
           (is (false? (await-fn term-timeout-ms))
@@ -182,7 +182,7 @@
               run-time-sec 5
               n-threads 2
               ;; each thread will have to sleep for ≈2 seconds
-              term-timeout-ms (total-wait-time rate n-threads)
+              term-timeout-ms (total-block-time rate n-threads)
               {:keys [await-fn count]} ((run-rate-limited-counting:custom-flag)
                                         rate-limiter n-threads run-time-sec)]
           (is (await-fn term-timeout-ms)


### PR DESCRIPTION
Hi @sunng87!

Here's a proposal for making the existing Rate Limiter implementation more malleable to changes, in particular to different sleep semantics. (This keeps the bucket’s tokens accounting logic intact, just improves the overall design a bit.)

The current `Thread/sleep` is interruptible in a sense that an `InterruptedException` is not given any special treatment, which may leave a rate limiter in an incorrect state wrt to the `:reserved-tokens` state. While this may not be _that_ critical for most applications (the state will be incorrect per se, but the calls will also not be executed, so the main rate limit invariant will be preserved), there are cases when the degradation of throughput is not desirable/acceptable — tight quotas, SLAs, multiple clients sharing the same limiter with a single quota, etc. In these cases it makes sense to have some sort of a rollback pattern in place (for instance, [like in Bucket4j methods](https://github.com/bucket4j/bucket4j/blob/c5aabec50723fcc83d52cfef347ed41e76a910a7/bucket4j-core/src/main/java/io/github/bucket4j/BlockingBucket.java#L181-L183)) so to keep the bucket’s token accounting correct.

A trivial example of such rollback function would be:

```clojure
(defn- rollback!
  "Undo a reservation of `permits` back into the bucket."
  [^TokenBucketRateLimiter rate-limiter permits]
  (swap! (.-state rate-limiter) update :reserved-tokens - permits))
```

which is to be called upon an `InterruptedException` during `Thread/sleep`. However, the existing design does not provide for such expansion, and I thought about how this could be added in the most unobtrusive way — an obvious candidate is to provide a new parameter, i.e. `sleep-fn`.

Another approach to the problem would be to have sleeps uninterruptible. For example, the [Bucket4j has](https://github.com/bucket4j/bucket4j/blob/c5aabec50723fcc83d52cfef347ed41e76a910a7/bucket4j-core/src/main/java/io/github/bucket4j/BlockingBucket.java#L124) [such blocking strategy built-in](https://github.com/bucket4j/bucket4j/blob/c5aabec50723fcc83d52cfef347ed41e76a910a7/bucket4j-core/src/main/java/io/github/bucket4j/UninterruptibleBlockingStrategy.java). While this may help keep the rate limiter in a correct state, it has its obvious drawbacks and it also requires similar redesign (a parametrisation with `sleep-fn`).

I tried to make commits atomic and self-explanatory. But, please, note that this is nothing more than a suggestion for possible design improvements. I am open to discussing any alternatives and/or changes, as well as eventually providing some concrete `sleep-fn` implementations (this PR is a groundwork, after all).

Cheers,
Mark