### PR TITLE
Support delayFn

### DIFF
--- a/src/diehard/core.clj
+++ b/src/diehard/core.clj
@@ -98,6 +98,14 @@
     (when-let [jitter (:jitter-ms policy-map)]
       (.withJitter policy (Duration/ofMillis jitter)))
 
+    (when-let [delay-fn (:delay-fn policy-map)]
+      (.withDelayFn policy
+                    (u/fn-as-contextual-supplier
+                     (fn [^ExecutionContext event]
+                       (with-context event
+                         (Duration/ofMillis (delay-fn (.getLastResult event)
+                                                      (.getLastException event))))))))
+
     ;; events
     (when-let [on-abort (:on-abort policy-map)]
       (.onAbort policy
@@ -178,6 +186,8 @@
   multiplier]` to control the delay between each retry, the delay for
   **n**th retry will be `(min (* initial-delay-ms (expt 2 (- n 1))) max-delay-ms)`
 * `:delay-ms` use constant delay between each retry
+* `:delay-fn` accepts a function which takes `result`, `exception` as
+  arguments, and returns a delay in ms
 * `:jitter-factor` random factor for each delay
 * `:jitter-ms` random time `(-jitter-ms, jitter-ms)` adds to each delay
 
@@ -257,6 +267,8 @@ the last execution. If `:circuit-breaker` is set, it will throw
   multiplier]` to control the delay between each retry, the delay for
   **n**th retry will be `(min (* initial-delay-ms (expt 2 (- n 1))) max-delay-ms)`
 * `:delay-ms` use constant delay between each retry
+* `:delay-fn` accepts a function which takes `result`, `exception` as
+  arguments, and returns a delay in ms
 * `:jitter-factor` random factor for each delay
 * `:jitter-ms` random time `(-jitter-ms, jitter-ms)` adds to each delay
 

--- a/src/diehard/spec.clj
+++ b/src/diehard/spec.clj
@@ -41,6 +41,7 @@
 (s/def :retry/max-retries int?)
 (s/def :retry/max-duration-ms int?)
 (s/def :retry/delay-ms int?)
+(s/def :retry/delay-fn fn?)
 
 (s/def :retry/jitter-factor double?)
 (s/def :retry/jitter-ms int?)
@@ -62,6 +63,7 @@
                       :retry/abort-if :retry/abort-on :retry/abort-when
                       :retry/backoff-ms :retry/max-retries :retry/max-duration-ms
                       :retry/delay-ms :retry/jitter-factor :retry/jitter-ms
+                      :retry/delay-fn
 
                       :retry/on-abort :retry/on-complete :retry/on-failed-attempt
                       :retry/on-failure :retry/on-retry :retry/on-retries-exceeded
@@ -73,6 +75,7 @@
                       :retry/abort-if :retry/abort-on :retry/abort-when
                       :retry/backoff-ms :retry/max-retries :retry/max-duration-ms
                       :retry/delay-ms :retry/jitter-factor :retry/jitter-ms
+                      :retry/delay-fn
 
                       :retry/on-abort :retry/on-complete :retry/on-failed-attempt
                       :retry/on-failure :retry/on-retry :retry/on-retries-exceeded

--- a/src/diehard/util.clj
+++ b/src/diehard/util.clj
@@ -1,8 +1,16 @@
 (ns ^:no-doc diehard.util
-  (:require [clojure.spec.alpha :as s])
-  (:import [dev.failsafe.function CheckedRunnable CheckedConsumer
-            CheckedFunction CheckedSupplier CheckedBiPredicate CheckedPredicate]
-           [dev.failsafe.event EventListener]))
+  (:require
+   [clojure.spec.alpha :as s])
+  (:import
+   [dev.failsafe.event EventListener]
+   [dev.failsafe.function
+    CheckedBiPredicate
+    CheckedConsumer
+    CheckedFunction
+    CheckedPredicate
+    CheckedRunnable
+    CheckedSupplier
+    ContextualSupplier]))
 
 (defn verify-opt-map-keys [opt-map allowed-keys]
   (doseq [k (keys opt-map)]
@@ -49,6 +57,10 @@
 
 (defn as-vector [v]
   (if (vector? v) v [v]))
+
+(defn fn-as-contextual-supplier [f]
+  (reify ContextualSupplier
+    (get [_ t] (f t))))
 
 (defn wrap-event-listener [f]
   (reify EventListener

--- a/test/diehard/core_test.clj
+++ b/test/diehard/core_test.clj
@@ -72,6 +72,17 @@
       (when (= *executions* 1)
         (>= (- *elapsed-time-ms* *start-time-ms*) 100))
       *executions*))
+  (testing "delay-fn"
+    (with-retry {:retry-if (fn [v e] (< v 3))
+                 :delay-fn (fn [v e] (cond
+                                       (= 1 v) 10
+                                       (= 2 v) 20
+                                       :else 0))}
+      (when (= *executions* 1)
+        (>= (- *elapsed-time-ms* *start-time-ms*) 10))
+      (when (= *executions* 1)
+        (>= (- *elapsed-time-ms* *start-time-ms*) 30))
+      *executions*))
   (testing "duration"
     (try
       (with-retry {:delay-ms 20


### PR DESCRIPTION
Add delay-fn support

Allows usage of withDelayFn which returns a float duration to indicate the next delay, or -1 o use the default duration.

https://failsafe.dev/javadoc/core/dev/failsafe/DelayablePolicyBuilder.html#withDelayFn-dev.failsafe.function.ContextualSupplier-

This is useful to us to respect [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After) headers